### PR TITLE
Refatorar análise de IA para processar todas as conversas

### DIFF
--- a/ia.js
+++ b/ia.js
@@ -35,16 +35,19 @@ async function analyzeConversation(conversation) {
     result = { resumo: '', intencoes: [], sugestao: '' };
   }
 
-  await saveAnalysis(conversation.cliente, result);
+  await saveAnalysis(conversation, result, prompt);
   return result;
 }
 
-async function saveAnalysis(cliente, resultado) {
+async function saveAnalysis(conversation, resultado, prompt) {
   const dir = path.join(__dirname, 'analises');
   await fs.promises.mkdir(dir, { recursive: true });
-  const date = new Date().toISOString().split('T')[0];
-  const file = path.join(dir, `${cliente}-${date}.json`);
-  await fs.promises.writeFile(file, JSON.stringify({ cliente, data: date, resultado }, null, 2));
+  const date = new Date().toISOString();
+  const file = path.join(dir, `${conversation.cliente}-${date.split('T')[0]}.json`);
+  const registro = { cliente: conversation.cliente, data: date, mensagens: conversation.mensagens, prompt, resultado };
+  await fs.promises.writeFile(file, JSON.stringify(registro, null, 2));
+  const logFile = path.join(dir, 'log.jsonl');
+  await fs.promises.appendFile(logFile, JSON.stringify(registro) + '\n');
 }
 
 module.exports = { analyzeConversation };

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -180,22 +180,7 @@
                     <h2>Inteligência Artificial</h2>
                     <input type="file" id="ia-file-input" accept="application/json" multiple style="display:none">
                     <button id="ia-load-files" class="btn-primary-alt"><i class="fas fa-upload"></i> Carregar Conversas</button>
-                    <div class="ia-client-select">
-                        <label for="ia-clients">Clientes:</label>
-                        <select id="ia-clients"></select>
-                    </div>
-                    <div id="ia-message-preview" class="ia-messages"></div>
-                    <button id="ia-analyze" class="btn-primary-alt">Analisar Conversa</button>
-                    <div id="ia-results" class="ia-results hidden">
-                        <ul class="ia-tabs">
-                            <li data-tab="resumo" class="active">Resumo</li>
-                            <li data-tab="intencoes">Intenções</li>
-                            <li data-tab="sugestao">Sugestão de Resposta</li>
-                        </ul>
-                        <div id="ia-resumo" class="ia-tab-content"></div>
-                        <div id="ia-intencoes" class="ia-tab-content hidden"></div>
-                        <div id="ia-sugestao" class="ia-tab-content hidden"></div>
-                    </div>
+                    <div id="ia-log" class="ia-log"></div>
                 </div>
             </div>
 

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -69,14 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- I.A. ---
     const iaFileInput = document.getElementById('ia-file-input');
     const iaLoadBtn = document.getElementById('ia-load-files');
-    const iaClientsSelect = document.getElementById('ia-clients');
-    const iaMessagePreview = document.getElementById('ia-message-preview');
-    const iaAnalyzeBtn = document.getElementById('ia-analyze');
-    const iaResults = document.getElementById('ia-results');
-    const iaTabs = iaResults ? iaResults.querySelectorAll('.ia-tabs li') : [];
-    const iaResumo = document.getElementById('ia-resumo');
-    const iaIntencoes = document.getElementById('ia-intencoes');
-    const iaSugestao = document.getElementById('ia-sugestao');
+    const iaLog = document.getElementById('ia-log');
 
     // --- Modal ---
     const modalOverlay = document.getElementById('custom-modal-overlay');
@@ -86,7 +79,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let whatsappAccountsMap = new Map();
     let serviceAccounts = [];
     let currentModalConfirmCallback = null;
-    let iaConversations = new Map();
 
     // --- Funções de Modal ---
     function showModal(title, message, type = 'info', onConfirm = null) {
@@ -622,67 +614,28 @@ document.addEventListener('DOMContentLoaded', () => {
         iaLoadBtn.addEventListener('click', () => iaFileInput.click());
 
         iaFileInput.addEventListener('change', async (e) => {
-            iaConversations.clear();
-            iaClientsSelect.innerHTML = '';
+            iaLog.innerHTML = '';
             const files = Array.from(e.target.files);
             for (const file of files) {
                 try {
                     const text = await file.text();
                     const json = JSON.parse(text);
-                    iaConversations.set(json.cliente, json);
-                    const norm = s => String(s).replace(/\D/g, '');
-                    const clientData = Array.from(clientsMap.values()).find(c => norm(c.phone) === norm(json.cliente));
-                    const option = document.createElement('option');
-                    option.value = json.cliente;
-                    option.textContent = `${clientData ? clientData.name : 'Desconhecido'} (${json.cliente})`;
-                    iaClientsSelect.appendChild(option);
+                    const result = await window.electronAPI.analyzeConversation(json);
+                    const item = document.createElement('div');
+                    item.classList.add('ia-log-item');
+                    if (result && result.success) {
+                        const { resumo, intencoes, sugestao } = result.result;
+                        item.innerHTML = `<strong>${json.cliente}</strong><br><em>Resumo:</em> ${resumo || ''}<br><em>Intenções:</em> <ul>` +
+                          (intencoes || []).map(i => `<li>${i}</li>`).join('') +
+                          `</ul><em>Sugestão:</em> ${sugestao || ''}`;
+                    } else {
+                        item.innerHTML = `<strong>${json.cliente}</strong><br>Erro ao analisar conversa.`;
+                    }
+                    iaLog.appendChild(item);
                 } catch (err) {
                     console.error('Erro ao ler arquivo IA', err);
                 }
             }
-            if (iaClientsSelect.options.length > 0) {
-                iaClientsSelect.selectedIndex = 0;
-                iaClientsSelect.dispatchEvent(new Event('change'));
-            }
-        });
-
-        iaClientsSelect.addEventListener('change', () => {
-            const conv = iaConversations.get(iaClientsSelect.value);
-            if (!conv) { iaMessagePreview.textContent = ''; return; }
-            const lastMsgs = conv.mensagens.slice(-5).map(m => `${m.hora} - ${m.de}: ${m.texto}`).join('\n');
-            iaMessagePreview.textContent = lastMsgs;
-        });
-
-        iaAnalyzeBtn.addEventListener('click', async () => {
-            const conv = iaConversations.get(iaClientsSelect.value);
-            if (!conv) return;
-            iaAnalyzeBtn.textContent = 'Analisando...';
-            iaAnalyzeBtn.disabled = true;
-            const result = await window.electronAPI.analyzeConversation(conv);
-            iaAnalyzeBtn.textContent = 'Analisar Conversa';
-            iaAnalyzeBtn.disabled = false;
-            if (result && result.success) {
-                iaResults.classList.remove('hidden');
-                iaTabs.forEach(t => t.classList.remove('active'));
-                if (iaTabs[0]) iaTabs[0].classList.add('active');
-                [iaResumo, iaIntencoes, iaSugestao].forEach(el => el.classList.add('hidden'));
-                iaResumo.classList.remove('hidden');
-                iaResumo.textContent = result.result.resumo || '';
-                iaIntencoes.innerHTML = '<ul>' + (result.result.intencoes || []).map(i => `<li>${i}</li>`).join('') + '</ul>';
-                iaSugestao.textContent = result.result.sugestao || '';
-            }
-        });
-
-        iaTabs.forEach(tab => {
-            tab.addEventListener('click', () => {
-                iaTabs.forEach(t => t.classList.remove('active'));
-                tab.classList.add('active');
-                const tabId = tab.dataset.tab;
-                [iaResumo, iaIntencoes, iaSugestao].forEach(el => el.classList.add('hidden'));
-                if (tabId === 'resumo') iaResumo.classList.remove('hidden');
-                if (tabId === 'intencoes') iaIntencoes.classList.remove('hidden');
-                if (tabId === 'sugestao') iaSugestao.classList.remove('hidden');
-            });
         });
 
         // Listeners do Main Process

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -239,10 +239,5 @@ button:disabled { background-color: #555; cursor: not-allowed; }
 .hidden { display: none !important; }
 
 /* Aba I.A. */
-.ia-client-select { margin: 15px 0; }
-.ia-messages { background: #f5f5f5; padding: 10px; max-height: 150px; overflow-y: auto; margin-bottom: 10px; color: #000; }
-.ia-results { margin-top: 20px; }
-.ia-tabs { list-style: none; padding: 0; display: flex; gap: 10px; }
-.ia-tabs li { cursor: pointer; padding: 5px 10px; background: #ddd; border-radius: 4px; color: #000; }
-.ia-tabs li.active { background: #bbb; }
-.ia-tab-content { margin-top: 10px; }
+.ia-log { background: #f5f5f5; padding: 10px; max-height: 150px; overflow-y: auto; margin: 15px 0; color: #000; }
+.ia-log-item { margin-bottom: 10px; }


### PR DESCRIPTION
## Resumo
- Removida a seleção de clientes e pré-visualização de mensagens na aba de IA
- Conversas carregadas são analisadas automaticamente e resultados ficam registrados em log
- Salvamento dos dados e prompts em `analises/log.jsonl` para reuso e treinamento

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a3f59c6a30832298b6a09d8eaae7cd