### PR TITLE
Trata ausência do módulo sqlite3 no carregamento

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Gerenciador de clientes com lembretes automáticos via WhatsApp. O projeto utili
 ## Requisitos
 - [Node.js](https://nodejs.org/) 18 ou superior.
 - NPM ou Yarn.
+- Para registrar análises de conversas, o módulo nativo `sqlite3` deve estar instalado.
 
 ## Instalação
 ```bash


### PR DESCRIPTION
## Resumo
- Evita falha no `ia.js` quando o módulo `sqlite3` não está instalado
- Documenta no README que o `sqlite3` é necessário para registrar análises

